### PR TITLE
feat(registry): add pull=never to container definition

### DIFF
--- a/ansible/roles/test/files/registry.container
+++ b/ansible/roles/test/files/registry.container
@@ -9,6 +9,7 @@ HostName=registry
 Image=docker.io/library/registry:latest
 Volume=/home/registry:/var/lib/registry:Z
 PublishPort=5000:5000
+Pull=Never
 [Service]
 TimeoutStartSec=0
 Restart=always


### PR DESCRIPTION
This prevents automatic pulling of the registry image, ensuring the image used is the one pre-loaded into the environment.