### PR TITLE
fix(test): correct hostname in kickstart and update packages

### DIFF
--- a/ansible/roles/test/files/lenovo_launch_sms.sh
+++ b/ansible/roles/test/files/lenovo_launch_sms.sh
@@ -51,7 +51,7 @@ ansible-playbook \
 	-i inventory/test \
 	roles/test/ohpc-lenovo-repo.yml
 cd ..
-ssh "${BOOT_SERVER}" systemctl start dhcpd
+ssh "${BOOT_SERVER}" systemctl start kea-dhcp4
 echo -n "----> Switching boot device to PXE: "
 export IPMI_PASSWORD=${SMS_IPMI_PASSWORD}
 /usr/bin/ipmitool -E -I lanplus -H "${BMC}" -U "${SMS_IPMI_USER}" chassis bootdev pxe options=efiboot
@@ -87,7 +87,7 @@ ssh-keygen -R "${TARGET}"
 ssh -o StrictHostKeyChecking=accept-new "${TARGET}" hostname
 
 # The boot server only has dhcpd enabled during SMS installation
-ssh "${BOOT_SERVER}" systemctl stop dhcpd
+ssh "${BOOT_SERVER}" systemctl stop kea-dhcp4
 
 cd ansible || exit
 ansible-playbook --extra-vars "distro=${OS} release=${RELEASE}" -i inventory/test roles/test/ohpc-lenovo-sms.yml

--- a/ansible/roles/test/ohpc-lenovo-repo.yml
+++ b/ansible/roles/test/ohpc-lenovo-repo.yml
@@ -29,6 +29,7 @@
         - /var/www/html/Rocky-8-latest
         - /root/.cache
         - /home/registry
+        - /results
       tags:
         - skip_ansible_lint
 
@@ -49,7 +50,13 @@
           - firewalld
           - podman
           - python3-policycoreutils
+          - ansible-core
+          - ansible-collection-community-general
+          - ansible-collection-ansible-posix
           - wget
+          - screen
+          - nmap-ncat
+          - python3-virtualenv
 
     - name: Import ohpc-lenovo-common.yml
       ansible.builtin.import_tasks: ohpc-lenovo-common.yml

--- a/ansible/roles/test/ohpc-lenovo-sms.yml
+++ b/ansible/roles/test/ohpc-lenovo-sms.yml
@@ -87,7 +87,7 @@
       - bats
     when: distro != "leap15.3"
 
-  - import_tasks: test-lenovo-common.yml
+  - import_tasks: ohpc-lenovo-common.yml
 
   - name: create directories
     file: dest="{{item}}" state=directory

--- a/ansible/roles/test/templates/el-kickstart.lenovo
+++ b/ansible/roles/test/templates/el-kickstart.lenovo
@@ -50,7 +50,7 @@ perl-ph
 lang en_US.UTF-8
 
 {% if inventory_hostname_short.startswith('ohpc-lenovo-repo') %}
-network --hostname=openhpc-lenovo-jenkins-sms --device=ens2f0 --ip=10.241.58.134 --netmask=255.255.255.240 --gateway=10.241.58.129 --bootproto=static --nameserver=1.1.1.1
+network --hostname=ohpc-lenovo-sms --device=ens2f0 --ip=10.241.58.134 --netmask=255.255.255.240 --gateway=10.241.58.129 --bootproto=static --nameserver=1.1.1.1
 {% endif %}
 {% if inventory_hostname_short.startswith('ohpc-huawei-repo') %}
 {% if distro.startswith('rocky') or distro.startswith('almalinux') %}


### PR DESCRIPTION
This commit fixes the hostname in the kickstart template and updates the list of installed packages in the ansible configuration. It also updates the dhcpd service to kea-dhcp4