### PR TITLE
refactor(ansible): rename jenkins sms role to generic sms role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ shfmt-lint:
 ansible-lint:
 	@echo "Running 'ansible-lint' on selected yaml files"
 	ansible-lint --offline ansible/roles/test/ohpc-huawei-*yml \
-		ansible/roles/test/ohpc-lenovo-repo.yml \
+		ansible/roles/test/ohpc-lenovo-*yml \
 		ansible/roles/common/automatic-updates.yml \
 		ansible/roles/common/handlers.yml \
 		ansible/roles/repos/repos-aarch64.yml \

--- a/ansible/inventory/test
+++ b/ansible/inventory/test
@@ -10,6 +10,6 @@ ohpc-huawei-repo
 [ohpc_lenovo_repo]
 ohpc-lenovo-repo
 
-[openhpc_lenovo_jenkins_sms]
-openhpc-lenovo-jenkins-sms
+[ohpc_lenovo_sms]
+ohpc-lenovo-sms
 

--- a/ansible/roles/test/ohpc-lenovo-sms.yml
+++ b/ansible/roles/test/ohpc-lenovo-sms.yml
@@ -1,125 +1,132 @@
-- name: openhpc-lenovo-jenkins-sms
-  hosts: openhpc_lenovo_jenkins_sms
-  gather_facts: True
+- name: Configure ohpc-lenovo-sms
+  hosts: ohpc_lenovo_sms
+  gather_facts: true
+  handlers:
+    - name: Include handlers
+      ansible.builtin.import_tasks: ../common/handlers.yml
+
   tasks:
-  - name: configure proxy
-    copy:
-      dest: /etc/profile.d/proxy.sh
-      content: |
-        export https_proxy=http://10.241.58.130:3128
-        export http_proxy=http://10.241.58.130:3128
+    - name: Include history.yml
+      ansible.builtin.include_tasks: ../common/history.yml
 
-  - name: fix dnf.conf
-    ansible.builtin.lineinfile:
-      path: /etc/dnf/dnf.conf
-      line: "{{ item }}"
-    with_items:
-      - user_agent="curl"
-    when: (distro.startswith("rocky")) or (distro == "almalinux9") or (distro.startswith("openEuler"))
+    - name: Configure proxy
+      ansible.builtin.copy:
+        dest: /etc/profile.d/proxy.sh
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          export https_proxy=http://10.241.58.130:3128
+          export http_proxy=http://10.241.58.130:3128
 
-  - name: Replace mirror URL for openeuler
-    ansible.builtin.replace:
-      path: /etc/yum.repos.d/openEuler.repo
-      regexp: 'repo.openeuler.org'
-      replace: 'repo.huaweicloud.com/openeuler'
-    when: distro == "openEuler_22.03"
+    - name: Fix dnf.conf
+      ansible.builtin.lineinfile:
+        path: /etc/dnf/dnf.conf
+        line: "{{ item }}"
+      with_items:
+        - user_agent="curl"
+      when: (distro.startswith("rocky")) or (distro == "almalinux9") or (distro.startswith("openEuler"))
 
-  - name: install obs repository configuration
-    template:
-      src: "{{ item }}"
-      dest: /etc/yum.repos.d/
-      owner: root
-      group: root
-      mode: 0644
-    with_items:
-      - OpenHPC-obs-factory.repo
-    when: distro == "openEuler_22.03"
+    - name: Replace mirror URL for openeuler
+      ansible.builtin.replace:
+        path: /etc/yum.repos.d/openEuler.repo
+        regexp: 'repo.openeuler.org'
+        replace: 'repo.huaweicloud.com/openeuler'
+      when: distro == "openEuler_22.03"
 
-  - name: install obs repository configuration
-    copy:
-      src: "{{ item }}"
-      dest: /etc/yum.repos.d/
-      owner: root
-      group: root
-      mode: 0644
-    with_items:
-      - mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
-    when: distro == "openEuler_22.03"
+    - name: Install obs repository configuration
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: /etc/yum.repos.d/
+        owner: root
+        group: root
+        mode: "0644"
+      with_items:
+        - OpenHPC-obs-factory.repo
+      when: distro == "openEuler_22.03"
 
-  - name: install obs repository configuration
-    template:
-      src: "{{ item }}"
-      dest: /etc/yum.repos.d/
-      owner: root
-      group: root
-      mode: 0644
-    with_items:
-      - OpenHPC-obs-factory.repo
-    when: (distro.startswith("rocky")) or (distro == "almalinux9")
+    - name: Install obs repository configuration
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: /etc/yum.repos.d/
+        owner: root
+        group: root
+        mode: "0644"
+      with_items:
+        - mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
+      when: distro == "openEuler_22.03"
 
-  - name: install obs repository configuration
-    template:
-      src: "{{ item }}"
-      dest: /etc/zypp/repos.d/
-      owner: root
-      group: root
-      mode: 0644
-    with_items:
-      - OpenHPC-obs-factory.repo
-    when: distro.startswith("leap15")
+    - name: Install obs repository configuration
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: /etc/yum.repos.d/
+        owner: root
+        group: root
+        mode: "0644"
+      with_items:
+        - OpenHPC-obs-factory.repo
+      when: (distro.startswith("rocky")) or (distro == "almalinux9")
 
-  - name: install packages
-    package:
-      state: present
-      name:
-      - epel-release
-      - tzdata-java
-    when: (distro.startswith("rocky")) or (distro == "almalinux9")
+    - name: Install obs repository configuration
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: /etc/zypp/repos.d/
+        owner: root
+        group: root
+        mode: "0644"
+      with_items:
+        - OpenHPC-obs-factory.repo
+      when: distro.startswith("leap15")
 
-  - name: install packages
-    package:
-      state: present
-      name:
-      - git
-      - ipmitool
-      - rsync
-      - chrony
-      - bats
-    when: distro != "leap15.3"
+    - name: Install packages
+      ansible.builtin.package:
+        state: present
+        name:
+          - epel-release
+          - tzdata-java
+      when: (distro.startswith("rocky")) or (distro == "almalinux9")
 
-  - import_tasks: ohpc-lenovo-common.yml
+    - name: Install packages
+      ansible.builtin.package:
+        state: present
+        name:
+          - git
+          - ipmitool
+          - rsync
+          - chrony
+          - bats
+      when: distro != "leap15.3"
 
-  - name: create directories
-    file: dest="{{item}}" state=directory
-    with_items:
-    - /root/ci
+    - name: Import ohpc-lenovo-common.yml
+      ansible.builtin.import_tasks: ohpc-lenovo-common.yml
 
-  - name: copy helper scripts
-    copy:
-      src: "{{ item }}"
-      dest: /root/ci/
-      owner: root
-      group: root
-    with_items:
-      - install.sh
-      - support_functions.sh
-      - computes_installed.py
-      - sms_installed.bats
-      - gen_inputs.pl
+    - name: Create directories
+      ansible.builtin.file:
+        dest: "{{ item }}"
+        state: directory
+        mode: "0755"
+      with_items:
+        - /root/ci
 
-  - name: copy helper scripts
-    template:
-      src: "{{ item }}"
-      dest: /root/ci/
-      owner: root
-      group: root
-    with_items:
-      - lenovo.mapping
+    - name: Copy helper scripts
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: /root/ci/
+        owner: root
+        group: root
+        mode: "0644"
+      with_items:
+        - install.sh
+        - support_functions.sh
+        - computes_installed.py
+        - sms_installed.bats
+        - gen_inputs.pl
+        - lenovo.mapping
 
-  - name: make install script executable
-    ansible.builtin.file:
-      path: "/root/ci/{{ item }}"
-      mode: '0755'
-    with_items:
-      - install.sh
-      - sms_installed.bats
+    - name: Make install script executable
+      ansible.builtin.file:
+        path: "/root/ci/{{ item }}"
+        mode: '0755'
+      with_items:
+        - install.sh
+        - sms_installed.bats

--- a/ansible/roles/test/templates/lenovo.mapping
+++ b/ansible/roles/test/templates/lenovo.mapping
@@ -37,27 +37,27 @@ eth_provision=eth2
 eth_provision=eth2
 {% endif %}
 
-openhpc-lenovo-jenkins-sms_ip=10.241.58.134
+ohpc-lenovo-sms_ip=10.241.58.134
 
 bmc_username=root
 
 # Compute node IPs
 
-openhpc-lenovo-jenkins-c1_ip=10.241.58.132
-openhpc-lenovo-jenkins-c2_ip=10.241.58.133
+ohpc-lenovo-c1_ip=10.241.58.132
+ohpc-lenovo-c2_ip=10.241.58.133
 
 # Compute node BMCs
 
-openhpc-lenovo-jenkins-c1_bmc=10.241.58.139
-openhpc-lenovo-jenkins-c2_bmc=10.241.58.138
+ohpc-lenovo-c1_bmc=10.241.58.139
+ohpc-lenovo-c2_bmc=10.241.58.138
 
 # Compute node MACs
 
-openhpc-lenovo-jenkins-c1_mac=f4:c7:aa:44:41:4a
-openhpc-lenovo-jenkins-c2_mac=f4:c7:aa:44:40:f0
+ohpc-lenovo-c1_mac=f4:c7:aa:44:41:4a
+ohpc-lenovo-c2_mac=f4:c7:aa:44:40:f0
 
 
 # Compute node IPoIB (not used)
 
-openhpc-lenovo-jenkins-c1_ipoib=172.17.1.1
-openhpc-lenovo-jenkins-c2_ipoib=172.17.1.2
+ohpc-lenovo-c1_ipoib=172.17.1.1
+ohpc-lenovo-c2_ipoib=172.17.1.2


### PR DESCRIPTION
This commit refactors the ansible roles and inventory to remove the jenkins-specific naming and use a generic sms role name. This allows the role to be used for more than just jenkins testing.