### PR TITLE
fix(test): add sleep to ensure system reboot before checking ssh

### DIFF
--- a/ansible/roles/test/files/lenovo_launch_sms.sh
+++ b/ansible/roles/test/files/lenovo_launch_sms.sh
@@ -60,6 +60,8 @@ echo -n "----> Rebooting ${TARGET}: "
 echo "----> done"
 
 echo "--> Waiting for ${TARGET} to finish installation"
+# Wait some time to make sure the system is rebooting
+sleep 15
 # This can take up to 30 minutes
 for i in $(seq 90 -1 1); do
 	echo "----> ${i}"


### PR DESCRIPTION
Add a sleep command to ensure the system has enough time to reboot before attempting to connect via SSH. This prevents false negatives during the installation process.