### PR TITLE
refactor(ansible): consolidate common sms tasks into a single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ shfmt-lint:
 ansible-lint:
 	@echo "Running 'ansible-lint' on selected yaml files"
 	ansible-lint --offline ansible/roles/test/ohpc-huawei-*yml \
+		ansible/roles/test/ohpc-common-sms.yml \
 		ansible/roles/test/ohpc-lenovo-*yml \
 		ansible/roles/common/automatic-updates.yml \
 		ansible/roles/common/handlers.yml \

--- a/ansible/roles/test/files/proxy.sh.huawei
+++ b/ansible/roles/test/files/proxy.sh.huawei
@@ -1,0 +1,3 @@
+export https_proxy=http://175.200.16.14:3128
+export http_proxy=http://175.200.16.14:3128
+export no_proxy="ohpc-huawei-repo,test.openhpc.community,pypi.org,192.168.243.4,175.200.16.14"

--- a/ansible/roles/test/files/proxy.sh.lenovo
+++ b/ansible/roles/test/files/proxy.sh.lenovo
@@ -1,0 +1,2 @@
+export https_proxy=http://10.241.58.130:3128
+export http_proxy=http://10.241.58.130:3128

--- a/ansible/roles/test/ohpc-common-sms.yml
+++ b/ansible/roles/test/ohpc-common-sms.yml
@@ -1,0 +1,132 @@
+---
+
+- name: Configure proxy
+  ansible.builtin.copy:
+    dest: /etc/profile.d/proxy.sh
+    src: "proxy.sh.{{ cluster }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Include history.yml
+  ansible.builtin.include_tasks: ../common/history.yml
+
+- name: Install obs repository configuration
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - OpenHPC-obs-factory.repo
+  when: distro == "openEuler_22.03"
+
+- name: Install obs repository configuration
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
+  when: distro == "openEuler_22.03"
+
+- name: Install obs repository configuration
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - OpenHPC-obs-factory.repo
+  when: (distro.startswith("rocky")) or (distro == "almalinux9")
+
+- name: Install obs repository configuration
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - arm1.repo
+  when: ((distro.startswith("rocky")) or (distro == "almalinux9")) and (cluster == "huawei")
+
+- name: Install obs repository configuration
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: /etc/zypp/repos.d/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - OpenHPC-obs-factory.repo
+  when: distro.startswith("leap15")
+
+- name: Install packages
+  ansible.builtin.package:
+    state: present
+    name:
+      - epel-release
+      - tzdata-java
+  when: (distro.startswith("rocky")) or (distro == "almalinux9")
+
+- name: Install packages
+  ansible.builtin.package:
+    state: present
+    name:
+      - openvpn
+      - bind-utils
+      - git
+      - ipmitool
+      - rsync
+      - chrony
+      - bats
+  when: distro != "leap15.3"
+
+- name: "Import ohpc-cluster-common.yml for {{ cluster }}"
+  ansible.builtin.import_tasks: "ohpc-{{ cluster }}-common.yml"
+
+- name: Create directories
+  ansible.builtin.file:
+    dest: "{{ item }}"
+    state: directory
+    mode: "0755"
+  with_items:
+    - /root/ci
+
+- name: Copy helper scripts
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /root/ci/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - install.sh
+    - support_functions.sh
+    - computes_installed.py
+    - sms_installed.bats
+    - gen_inputs.pl
+
+- name: Install installation templates
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: /root/ci/
+    owner: root
+    group: root
+    mode: "0644"
+  with_items:
+    - "{{ cluster }}.mapping"
+
+
+- name: Make install script executable
+  ansible.builtin.file:
+    path: "/root/ci/{{ item }}"
+    mode: "0755"
+  with_items:
+    - install.sh
+    - sms_installed.bats

--- a/ansible/roles/test/ohpc-huawei-sms.yml
+++ b/ansible/roles/test/ohpc-huawei-sms.yml
@@ -2,6 +2,7 @@
   hosts: ohpc_huawei_sms
   gather_facts: true
   vars:
+    cluster: huawei
     local_hostname: ohpc-huawei-sms-internal
 
   handlers:
@@ -9,82 +10,8 @@
       ansible.builtin.import_tasks: ../common/handlers.yml
 
   tasks:
-    - name: Configure proxy
-      ansible.builtin.copy:
-        dest: /etc/profile.d/proxy.sh
-        mode: "0644"
-        content: |
-          export https_proxy=http://175.200.16.14:3128
-          export http_proxy=http://175.200.16.14:3128
-          export no_proxy="ohpc-huawei-repo,test.openhpc.community,pypi.org,192.168.243.4,175.200.16.14"
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-      when: distro == "openEuler_22.03"
-
-    - name: Install obs repository configuration
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
-      when: distro == "openEuler_22.03"
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-        - arm1.repo
-      when: (distro.startswith("rocky")) or (distro == "almalinux9")
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/zypp/repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-      when: distro == "leap15.5"
-
-    - name: Install packages
-      ansible.builtin.package:
-        state: present
-        name:
-          - epel-release
-          - tzdata-java
-      when: (distro.startswith("rocky")) or (distro == "almalinux9")
-
-    - name: Install packages
-      ansible.builtin.package:
-        state: present
-        name:
-          - openvpn
-          - bind-utils
-          - git
-          - ipmitool
-          - rsync
-          - chrony
-          - bats
-
-    - name: Include ohpc-huawei-common.yml
-      ansible.builtin.import_tasks: ohpc-huawei-common.yml
+    - name: Include ohpc-common-sms.yml
+      ansible.builtin.include_tasks: ohpc-common-sms.yml
 
     - name: Sync time from repo
       ansible.builtin.lineinfile:
@@ -100,43 +27,3 @@
         line: 'makestep 1 -1'
       notify:
         - Restart chronyd
-
-    - name: Create directories
-      ansible.builtin.file:
-        dest: "{{ item }}"
-        state: directory
-        mode: "0755"
-      with_items:
-        - /root/ci
-
-    - name: Copy helper scripts
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /root/ci/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - install.sh
-        - support_functions.sh
-        - computes_installed.py
-        - sms_installed.bats
-        - gen_inputs.pl
-
-    - name: Install installation templates
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /root/ci/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - huawei.mapping
-
-    - name: Make install script executable
-      ansible.builtin.file:
-        path: "/root/ci/{{ item }}"
-        mode: "0755"
-      with_items:
-        - install.sh
-        - sms_installed.bats

--- a/ansible/roles/test/ohpc-lenovo-sms.yml
+++ b/ansible/roles/test/ohpc-lenovo-sms.yml
@@ -1,23 +1,15 @@
 - name: Configure ohpc-lenovo-sms
   hosts: ohpc_lenovo_sms
   gather_facts: true
+  vars:
+    cluster: lenovo
   handlers:
     - name: Include handlers
       ansible.builtin.import_tasks: ../common/handlers.yml
 
   tasks:
-    - name: Include history.yml
-      ansible.builtin.include_tasks: ../common/history.yml
-
-    - name: Configure proxy
-      ansible.builtin.copy:
-        dest: /etc/profile.d/proxy.sh
-        owner: root
-        group: root
-        mode: "0644"
-        content: |
-          export https_proxy=http://10.241.58.130:3128
-          export http_proxy=http://10.241.58.130:3128
+    - name: Include ohpc-common-sms.yml
+      ansible.builtin.include_tasks: ohpc-common-sms.yml
 
     - name: Fix dnf.conf
       ansible.builtin.lineinfile:
@@ -33,100 +25,3 @@
         regexp: 'repo.openeuler.org'
         replace: 'repo.huaweicloud.com/openeuler'
       when: distro == "openEuler_22.03"
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-      when: distro == "openEuler_22.03"
-
-    - name: Install obs repository configuration
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
-      when: distro == "openEuler_22.03"
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/yum.repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-      when: (distro.startswith("rocky")) or (distro == "almalinux9")
-
-    - name: Install obs repository configuration
-      ansible.builtin.template:
-        src: "{{ item }}"
-        dest: /etc/zypp/repos.d/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - OpenHPC-obs-factory.repo
-      when: distro.startswith("leap15")
-
-    - name: Install packages
-      ansible.builtin.package:
-        state: present
-        name:
-          - epel-release
-          - tzdata-java
-      when: (distro.startswith("rocky")) or (distro == "almalinux9")
-
-    - name: Install packages
-      ansible.builtin.package:
-        state: present
-        name:
-          - git
-          - ipmitool
-          - rsync
-          - chrony
-          - bats
-      when: distro != "leap15.3"
-
-    - name: Import ohpc-lenovo-common.yml
-      ansible.builtin.import_tasks: ohpc-lenovo-common.yml
-
-    - name: Create directories
-      ansible.builtin.file:
-        dest: "{{ item }}"
-        state: directory
-        mode: "0755"
-      with_items:
-        - /root/ci
-
-    - name: Copy helper scripts
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: /root/ci/
-        owner: root
-        group: root
-        mode: "0644"
-      with_items:
-        - install.sh
-        - support_functions.sh
-        - computes_installed.py
-        - sms_installed.bats
-        - gen_inputs.pl
-        - lenovo.mapping
-
-    - name: Make install script executable
-      ansible.builtin.file:
-        path: "/root/ci/{{ item }}"
-        mode: '0755'
-      with_items:
-        - install.sh
-        - sms_installed.bats


### PR DESCRIPTION
This commit refactors the Ansible playbooks for SMS configuration by consolidating common tasks into a single file (ohpc-common-sms.yml). This eliminates redundancy and improves maintainability across different cluster types (huawei, lenovo). It includes proxy configuration, repository setup, package installation, and helper script deployment. Specific tasks are included based on the cluster type.