### PR TITLE
feat(firewall): add tun1 interface and obs access to public zone

### DIFF
--- a/ansible/roles/test/ohpc-lenovo-repo.yml
+++ b/ansible/roles/test/ohpc-lenovo-repo.yml
@@ -17,3 +17,23 @@
   tasks:
     - name: Include ohpc-common-repo.yml
       ansible.builtin.include_tasks: ohpc-common-repo.yml
+
+    - name: Add tun1 to public zone
+      ansible.posix.firewalld:
+        zone: public
+        interface: tun1
+        permanent: true
+        immediate: true
+        state: enabled
+      tags:
+        - skip_ansible_lint
+
+    - name: Allow access to 10.255.255.1 (obs via vpn)
+      ansible.posix.firewalld:
+        zone: public
+        rich_rule: rule family="ipv4" destination address="10.255.255.1" accept
+        permanent: true
+        immediate: true
+        state: enabled
+      tags:
+        - skip_ansible_lint


### PR DESCRIPTION
This commit configures the firewall on the ohpc-lenovo-repo hosts. It adds the tun1 interface to the public zone and allows access to 10.255.255.1 (obs via vpn) through a rich rule. These changes are made persistent and applied immediately.