### PR TITLE
feat: add link_mpi_to_non_mpi config and update mpi_dependent list

### DIFF
--- a/obs/config
+++ b/obs/config
@@ -53,15 +53,15 @@ compiler_dependent = ["openmpi", "mpich", "mvapich2", "openblas", "R", "likwid",
 standalone = ["docs", "test-suite", "warewulf", "gnu-compilers", "ohpc-filesystem",
               "cmake", "pdsh", "intel-compilers-devel","autoconf","automake", "pmix",
               "impi-devel", "meta-packages", "easybuild", "spack", "hwloc", "ucx",
-              "libfabric", "python-Cython", "openpbs",
+              "python-Cython", "openpbs", "libtool", "prun",
               "lmod", "genders", "hpc-workspace", "valgrind", "slurm", "cuda-devel"]
 
-#mpi_dependent = ["otf2", "sionlib", "!fftw", "scalapack",
-#		 "scorep", "scalasca", "!scipy", "phdf5", "netcdf", "netcdf-fortran",
-#		 "!netcdf-cxx", "lmod-defaults", "!geopm", "!mumps", "omb",
-#		 "ptscotch", "boost", "pnetcdf", "!tau", "!extrae", "!imb",
-#		 "!opencoarrays", "hypre", "!mpi4py", "dimemas", "!adios2",
-#		 "!trilinos", "petsc", "!slepc", "superlu_dist", "mfem"]
+mpi_dependent = ["!otf2", "!sionlib", "!fftw", "!scalapack",
+		 "!scorep", "!scalasca", "!scipy", "phdf5", "netcdf", "!netcdf-fortran",
+		 "!netcdf-cxx", "lmod-defaults", "!geopm", "!mumps", "omb",
+		 "!ptscotch", "!boost", "!pnetcdf", "!tau", "!extrae", "imb",
+		 "!opencoarrays", "!hypre", "!mpi4py", "!dimemas", "!adios2",
+		 "!trilinos", "!petsc", "!slepc", "!superlu_dist", "!mfem"]
 skip_on_distro_openEuler_22.03 = ["-arm1","-intel","-impi","impi-devel","intel-compilers-devel",
 				  "arm-compilers-devel","warewulf","cuda-devel"]
 openblas_compiler=["gnu15"]

--- a/obs/link_mpi_to_non_mpi
+++ b/obs/link_mpi_to_non_mpi
@@ -1,0 +1,22 @@
+<!-- OpenHPC OBS configuration files -->
+
+<!--
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+-->
+
+<link project='!PROJECT!' package='!PACKAGE!'>
+<patches>
+	<topadd>%define compiler_family !COMPILER!</topadd>
+	<topadd>%define ohpc_mpi_dependent 0</topadd>
+</patches>
+</link>


### PR DESCRIPTION
This commit adds a new configuration file, link_mpi_to_non_mpi, and updates the mpi_dependent list in the obs/config file. The new config file is used to set compiler family and ohpc_mpi_dependent. The mpi_dependent list has been updated with some packages.